### PR TITLE
[UPD.ino] Change CapacityMode from 2 (%) to 0 (mAh)

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -16,7 +16,7 @@ const byte bOEMVendor = IOEMVENDOR;
 uint16_t iPresentStatus = 0, iPreviousStatus = 0;
 
 byte bRechargable = 1;
-byte bCapacityMode = 2;  // units are in %%
+byte bCapacityMode = 0;  // unit: 0=mAh, 1=mWh, 2=%
 
 // Physical parameters
 const uint16_t iConfigVoltage = 1380;


### PR DESCRIPTION
This fixes #11 by also reporting battery capacity percentage on Windows laptops that already has a battery. This makes the sample more interesting to demonstrate.

The total battery charge % reported by Windows appear to be a weighted sum of each battery, weighted by their respective capacities. The Arduino battery is currently harcoded to `iFullChargeCapacity = 100` mAh, which is quite small. It does therefore have a relatively low influence on the total battery charge % on the laptop I've tested on.

## Screenshots of 84% charge
On Windows, the Arduino appear as an additional battery with a separate charge %:  
![image](https://github.com/user-attachments/assets/e24d08b2-3abd-49ce-ae9b-e52f5547a15d)

On MacOS the  Arduino appear as a UPS battery with a separate charge %:  
![image](https://github.com/user-attachments/assets/c9d781bc-2c7b-4373-8761-f0b03539d032)

On Fedora Linux the Arduino appears as a UPS battery with separate charge %:  
![image](https://github.com/user-attachments/assets/b793c220-cc6e-4ea3-9b0c-b53d27ed8dcc)

## Test setup
Arduino micro on breadboard with a potentiometer connected to `A7`:  
![image](https://github.com/user-attachments/assets/17956aa6-f0b1-4d5d-8cd1-fce22ab36ae8)

The `bCharging` variable is hardcoded, since I haven't connected any digital switch.

I also had to update `linux/98-upower-hid.rules` with `ATTRS{idProduct}=="8037"` to make Linux recognize the Arduino micro.
