### PR TITLE
Linux udev rule: Document need for updating idProduct to match Arduino board

### DIFF
--- a/linux/98-upower-hid.rules
+++ b/linux/98-upower-hid.rules
@@ -1,3 +1,4 @@
+# TODO: Adjust idProduct to match ProductID for the Arduino board used
 ATTRS{idVendor}=="2341", ENV{UPOWER_VENDOR}="Arduino"
 ATTRS{idVendor}=="2341", ATTRS{idProduct}=="8036", ENV{UPOWER_BATTERY_TYPE}="ups"
 


### PR DESCRIPTION
The rule is currently hardcoded to Arduino Leonardo (VID=2341, PID=8036). It therefore needs to be slightly modified to work against other boards, such as Arduino micro.