### PR TITLE
Inline HIDPowerDevice_ string IDs

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -235,6 +235,8 @@ void HIDPowerDevice_::begin(void) {
     
     const byte bProduct = IPRODUCT; // defined in Arduino <USBDesc.h>
     HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
+    
+    const byte bSerial = ISERIAL; // defined in Arduino <USBDesc.h>
     HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
     
     const byte bManufacturer = IMANUFACTURER; // defined in Arduino <USBDesc.h>

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -235,8 +235,9 @@ void HIDPowerDevice_::begin(void) {
     
     HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
     HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
-    HID().SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
     
+    const byte bManufacturer = IMANUFACTURER; // defined in Arduino <USBDesc.h>
+    HID().SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
 }
 
 void HIDPowerDevice_::setOutput(Serial_& out) {

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -233,6 +233,7 @@ void HIDPowerDevice_::begin(void) {
     
     // set string ID here
     
+    const byte bProduct = IPRODUCT; // defined in Arduino <USBDesc.h>
     HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
     HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
     

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -105,8 +105,6 @@ static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 class HIDPowerDevice_  {
     
 private:
-    
-    const byte bProduct = IPRODUCT;
     const byte bSerial = ISERIAL;  
     
 public:

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -107,7 +107,6 @@ class HIDPowerDevice_  {
 private:
     
     const byte bProduct = IPRODUCT;
-    const byte bManufacturer = IMANUFACTURER;
     const byte bSerial = ISERIAL;  
     
 public:

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -103,10 +103,6 @@ static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 
 
 class HIDPowerDevice_  {
-    
-private:
-    const byte bSerial = ISERIAL;  
-    
 public:
   HIDPowerDevice_(void);
   void begin(void);


### PR DESCRIPTION
Proposal to inline the `bProduct`, `bManufacturer` & `bSerial` members into the `HIDPowerDevice_::begin` method to simplify the code, since they're not used anywhere else.

The Arduino-defined `IPRODUCT`,  `IMANUFACTURER` & `ISERIAL` IDs are used directly in `_hidReportDescriptor`. I therefore assume that the `bProduct`, `bManufacturer` & `bSerial` members anyhow needs to be kept in sync with these defines.


