### PR TITLE
Remove begin/end methods to simplify the implementation

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -51,8 +51,6 @@ int iRes=0;
 void setup() {
 
   Serial.begin(57600);
-    
-  PowerDevice.begin();
   
   // Serial No is set in a special way as it forms Arduino port name
   PowerDevice.setSerial(STRING_SERIAL); 

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -263,9 +263,4 @@ HID_::HID_(void) : PluggableUSBModule(2, 1, epType),
     PluggableUSB().plug(this);
 }
 
-int HID_::begin(void)
-{
-    return 0;
-}
-
 #endif /* if defined(USBCON) */

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -114,7 +114,6 @@ class HID_ : public PluggableUSBModule
 {
 public:
     HID_(void);
-    int begin(void);
     int SendReport(uint16_t id, const void* data, int len);
     int SetFeature(uint16_t id, const void* data, int len);
     bool LockFeature(uint16_t id, bool lock);

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -225,15 +225,11 @@ HIDPowerDevice_::HIDPowerDevice_(void) {
     static HIDSubDescriptor node(_hidReportDescriptor, sizeof (_hidReportDescriptor));
 
     HID().AppendDescriptor(&node);
-}
 
-void HIDPowerDevice_::begin(void) {
     // set string ID here
-    
     HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
     HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
     HID().SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
-    
 }
 
 void HIDPowerDevice_::setOutput(Serial_& out) {

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -228,8 +228,6 @@ HIDPowerDevice_::HIDPowerDevice_(void) {
 }
 
 void HIDPowerDevice_::begin(void) {
-    HID().begin();
-    
     // set string ID here
     
     HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -246,9 +246,6 @@ void HIDPowerDevice_::setSerial(const char* s) {
     HID().setSerial(s);
 }
 
-void HIDPowerDevice_::end(void) {
-}
-
 int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
     uint16_t bval = (year - 1980)*512 + month * 32 + day;
     return HID().SendReport(id, &bval, sizeof (bval));

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -112,7 +112,6 @@ private:
     
 public:
   HIDPowerDevice_(void);
-  void begin(void);
   
   void setOutput(Serial_&);
   

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -118,9 +118,6 @@ public:
   
   void setSerial(const char*);
   
-  
-  void end(void);
-  
   int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
   int sendReport(uint16_t id, const void* bval, int len);
   


### PR DESCRIPTION
Proposal to simplify the implementation by avoiding the need for manually calling `begin()` before using `HIDPowerDevice_`.
