### PR TITLE
HID_: Make methods overridden from base-class explicit

### DIFF
--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -133,10 +133,10 @@ public:
     
 protected:
     // Implementation of the PluggableUSBModule
-    int getInterface(uint8_t* interfaceCount);
-    int getDescriptor(USBSetup& setup);
-    bool setup(USBSetup& setup);
-    uint8_t getShortName(char* name);
+    int getInterface(uint8_t* interfaceCount) override;
+    int getDescriptor(USBSetup& setup) override;
+    bool setup(USBSetup& setup) override;
+    uint8_t getShortName(char* name) override;
     
 private:
     uint8_t epType[2];


### PR DESCRIPTION
Fixes #20. Done to make it clear that these virtual methods are defined in the `PluggableUSBModule` base-class and might be called from external code not seen in this repo.