### PR TITLE
TAB to space conversion & consistent indentation

### DIFF
--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -39,9 +39,9 @@ int HID_::getInterface(uint8_t* interfaceCount)
     return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
-// Since this function is not exposed in USBCore API, had to replicate here.  
+// Since this function is not exposed in USBCore API, had to replicate here.
 static bool USB_SendStringDescriptor(const char* string_P, u8 string_len, uint8_t flags) {
-        
+
         u8 c[2] = {(u8)(2 + string_len * 2), 3};
 
         USB_SendControl(0,&c,2);
@@ -60,12 +60,12 @@ static bool USB_SendStringDescriptor(const char* string_P, u8 string_len, uint8_
 
 int HID_::getDescriptor(USBSetup& setup)
 {
-    
+
         u8 t = setup.wValueH;
-        
+
         // HID-specific strings
         if(USB_STRING_DESCRIPTOR_TYPE == t) {
-            
+
             // we place all strings in the 0xFF00-0xFFFE range
             HIDReport* rep = GetFeature(0xFF00 | setup.wValueL );
             if(rep) {
@@ -75,7 +75,7 @@ int HID_::getDescriptor(USBSetup& setup)
                 return 0;
             }
         }
-        
+
     // Check if this is a HID Class Descriptor request
     if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
     if (HID_REPORT_DESCRIPTOR_TYPE != t) { return 0; }
@@ -91,11 +91,11 @@ int HID_::getDescriptor(USBSetup& setup)
             return -1;
         total += res;
     }
-    
+
     // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
     // due to the USB specs, but Windows and Linux just assumes its in report mode.
     protocol = HID_REPORT_PROTOCOL;
-    
+
     return total;
 }
 
@@ -108,9 +108,9 @@ uint8_t HID_::getShortName(char *name)
         return strlen_P(serial);
     }
     else {
-        
+
         // default serial number
-        
+
     name[0] = 'H';
     name[1] = 'I';
     name[2] = 'D';
@@ -153,7 +153,7 @@ int HID_::SetFeature(uint16_t id, const void* data, int len)
         }
 
     }
-    
+
     reportCount++;
     return reportCount;
 }
@@ -194,31 +194,31 @@ HIDReport* HID_::GetFeature(uint16_t id)
 }
 
 bool HID_::setup(USBSetup& setup)
-{       
+{
     if (pluggedInterface != setup.wIndex) {
         return false;
     }
 
     uint8_t request = setup.bRequest;
     uint8_t requestType = setup.bmRequestType;
-        
+
     if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE)
-    {        
+    {
         if (request == HID_GET_REPORT) {
 
                         if(setup.wValueH == HID_REPORT_TYPE_FEATURE)
                         {
 
                             HIDReport* current = GetFeature(setup.wValueL);
-                            if(current){ 
+                            if(current){
                                 if(USB_SendControl(0, &(current->id), 1)>0 &&
                                    USB_SendControl(0, current->data, current->length)>0)
                                     return true;
                             }
 
                             return false;
-                            
-                        }    
+
+                        }
             return true;
         }
         if (request == HID_GET_PROTOCOL) {
@@ -231,7 +231,7 @@ bool HID_::setup(USBSetup& setup)
     }
 
     if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE)
-    {       
+    {
         if (request == HID_SET_PROTOCOL) {
             // The USB Host tells us if we are in boot or report mode.
             // This only works with a real boot compatible device.
@@ -248,15 +248,15 @@ bool HID_::setup(USBSetup& setup)
                         {
 
                             HIDReport* current = GetFeature(setup.wValueL);
-                            if(!current) return false;                              
-                            if(setup.wLength != current->length + 1) return false;  
-                            uint8_t* data = new uint8_t[setup.wLength];              
-                            USB_RecvControl(data, setup.wLength);                   
-                            if(*data != current->id) return false;                 
-                            memcpy((uint8_t*)current->data, data+1, current->length); 
-                            delete[] data;                                          
+                            if(!current) return false;
+                            if(setup.wLength != current->length + 1) return false;
+                            uint8_t* data = new uint8_t[setup.wLength];
+                            USB_RecvControl(data, setup.wLength);
+                            if(*data != current->id) return false;
+                            memcpy((uint8_t*)current->data, data+1, current->length);
+                            delete[] data;
                             return true;
-                            
+
                         }
 
         }

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -23,20 +23,20 @@
 
 HID_& HID()
 {
-	static HID_ obj;
-	return obj;
+    static HID_ obj;
+    return obj;
 }
 
 int HID_::getInterface(uint8_t* interfaceCount)
 {
-	*interfaceCount += 1; // uses 1
-	HIDDescriptor hidInterface = {
-		D_INTERFACE(pluggedInterface, 2, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
-		D_HIDREPORT(descriptorSize),
-		D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14),
+    *interfaceCount += 1; // uses 1
+    HIDDescriptor hidInterface = {
+        D_INTERFACE(pluggedInterface, 2, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
+        D_HIDREPORT(descriptorSize),
+        D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14),
                 D_ENDPOINT(USB_ENDPOINT_OUT(HID_RX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x0A)
-	};
-	return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
+    };
+    return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
 // Since this function is not exposed in USBCore API, had to replicate here.  
@@ -76,27 +76,27 @@ int HID_::getDescriptor(USBSetup& setup)
             }
         }
         
-	// Check if this is a HID Class Descriptor request
-	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
-	if (HID_REPORT_DESCRIPTOR_TYPE != t) { return 0; }
+    // Check if this is a HID Class Descriptor request
+    if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
+    if (HID_REPORT_DESCRIPTOR_TYPE != t) { return 0; }
 
-	// In a HID Class Descriptor wIndex cointains the interface number
-	if (setup.wIndex != pluggedInterface) { return 0; }
+    // In a HID Class Descriptor wIndex cointains the interface number
+    if (setup.wIndex != pluggedInterface) { return 0; }
 
-	int total = 0;
-	HIDSubDescriptor* node;
-	for (node = rootNode; node; node = node->next) {
-		int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
-		if (res == -1)
-			return -1;
-		total += res;
-	}
-	
-	// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-	// due to the USB specs, but Windows and Linux just assumes its in report mode.
-	protocol = HID_REPORT_PROTOCOL;
-	
-	return total;
+    int total = 0;
+    HIDSubDescriptor* node;
+    for (node = rootNode; node; node = node->next) {
+        int res = USB_SendControl(TRANSFER_PGM, node->data, node->length);
+        if (res == -1)
+            return -1;
+        total += res;
+    }
+    
+    // Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+    // due to the USB specs, but Windows and Linux just assumes its in report mode.
+    protocol = HID_REPORT_PROTOCOL;
+    
+    return total;
 }
 
 uint8_t HID_::getShortName(char *name)
@@ -111,27 +111,27 @@ uint8_t HID_::getShortName(char *name)
         
         // default serial number
         
-	name[0] = 'H';
-	name[1] = 'I';
-	name[2] = 'D';
-	name[3] = 'A' + (descriptorSize & 0x0F);
-	name[4] = 'A' + ((descriptorSize >> 4) & 0x0F);
-	return 5;
+    name[0] = 'H';
+    name[1] = 'I';
+    name[2] = 'D';
+    name[3] = 'A' + (descriptorSize & 0x0F);
+    name[4] = 'A' + ((descriptorSize >> 4) & 0x0F);
+    return 5;
     }
 }
 
 void HID_::AppendDescriptor(HIDSubDescriptor *node)
 {
-	if (!rootNode) {
-		rootNode = node;
-	} else {
-		HIDSubDescriptor *current = rootNode;
-		while (current->next) {
-			current = current->next;
-		}
-		current->next = node;
-	}
-	descriptorSize += node->length;
+    if (!rootNode) {
+        rootNode = node;
+    } else {
+        HIDSubDescriptor *current = rootNode;
+        while (current->next) {
+            current = current->next;
+        }
+        current->next = node;
+    }
+    descriptorSize += node->length;
 }
 
 int HID_::SetFeature(uint16_t id, const void* data, int len)
@@ -174,11 +174,11 @@ bool HID_::LockFeature(uint16_t id, bool lock) {
 
 int HID_::SendReport(uint16_t id, const void* data, int len)
 {
-	auto ret = USB_Send(HID_TX, &id, 1);
-	if (ret < 0) return ret;
-	auto ret2 = USB_Send(HID_TX | TRANSFER_RELEASE, data, len);
-	if (ret2 < 0) return ret2;
-	return ret + ret2;
+    auto ret = USB_Send(HID_TX, &id, 1);
+    if (ret < 0) return ret;
+    auto ret2 = USB_Send(HID_TX | TRANSFER_RELEASE, data, len);
+    if (ret2 < 0) return ret2;
+    return ret + ret2;
 }
 
 HIDReport* HID_::GetFeature(uint16_t id)
@@ -195,16 +195,16 @@ HIDReport* HID_::GetFeature(uint16_t id)
 
 bool HID_::setup(USBSetup& setup)
 {       
-	if (pluggedInterface != setup.wIndex) {
-		return false;
-	}
+    if (pluggedInterface != setup.wIndex) {
+        return false;
+    }
 
-	uint8_t request = setup.bRequest;
-	uint8_t requestType = setup.bmRequestType;
+    uint8_t request = setup.bRequest;
+    uint8_t requestType = setup.bmRequestType;
         
-	if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE)
-	{        
-		if (request == HID_GET_REPORT) {
+    if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE)
+    {        
+        if (request == HID_GET_REPORT) {
 
                         if(setup.wValueH == HID_REPORT_TYPE_FEATURE)
                         {
@@ -219,31 +219,31 @@ bool HID_::setup(USBSetup& setup)
                             return false;
                             
                         }    
-			return true;
-		}
-		if (request == HID_GET_PROTOCOL) {
-			// TODO: Send8(protocol);
-			return true;
-		}
-		if (request == HID_GET_IDLE) {
-			// TODO: Send8(idle);
-		}
-	}
+            return true;
+        }
+        if (request == HID_GET_PROTOCOL) {
+            // TODO: Send8(protocol);
+            return true;
+        }
+        if (request == HID_GET_IDLE) {
+            // TODO: Send8(idle);
+        }
+    }
 
-	if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE)
-	{       
-		if (request == HID_SET_PROTOCOL) {
-			// The USB Host tells us if we are in boot or report mode.
-			// This only works with a real boot compatible device.
-			protocol = setup.wValueL;
-			return true;
-		}
-		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
-			return true;
-		}
-		if (request == HID_SET_REPORT)
-		{
+    if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE)
+    {       
+        if (request == HID_SET_PROTOCOL) {
+            // The USB Host tells us if we are in boot or report mode.
+            // This only works with a real boot compatible device.
+            protocol = setup.wValueL;
+            return true;
+        }
+        if (request == HID_SET_IDLE) {
+            idle = setup.wValueL;
+            return true;
+        }
+        if (request == HID_SET_REPORT)
+        {
                         if(setup.wValueH == HID_REPORT_TYPE_FEATURE)
                         {
 
@@ -259,24 +259,24 @@ bool HID_::setup(USBSetup& setup)
                             
                         }
 
-		}
-	}
+        }
+    }
 
-	return false;
+    return false;
 }
 
 HID_::HID_(void) : PluggableUSBModule(2, 1, epType),
                    rootNode(NULL), descriptorSize(0),
                    protocol(HID_REPORT_PROTOCOL), idle(1)
 {
-	epType[0] = EP_TYPE_INTERRUPT_IN;
+    epType[0] = EP_TYPE_INTERRUPT_IN;
         epType[1] = EP_TYPE_INTERRUPT_OUT;
-	PluggableUSB().plug(this);
+    PluggableUSB().plug(this);
 }
 
 int HID_::begin(void)
 {
-	return 0;
+    return 0;
 }
 
 #endif /* if defined(USBCON) */


### PR DESCRIPTION
Done to consistently use space characters for whitespace. The current practice of using a mix of TAB and space leads to editor-dependent indentation.

Also, reduce unnecessary indentation to improve readability.


# Reviewing tip
You can hide whitespace changes when reviewing the changes through the GitHub web UI, This allows you to quickly verify that no accidental code changes have slipped in:  
![image](https://github.com/user-attachments/assets/e41dbf79-cc26-40ec-a144-8847a55a9827)
