### PR TITLE
Simplify PresentStatus handling with C++ bit-fields

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -106,29 +106,17 @@ void loop() {
   iRemaining = (byte)(round((float)100*iBattSoc/1024));
   iRunTimeToEmpty = (uint16_t)round((float)iAvgTimeToEmpty*iRemaining/100);
   
-    // Charging
-  if(bCharging) 
-    iPresentStatus.CHARGING = 1;
-  else
-    iPresentStatus.CHARGING = 0;
-  if(bACPresent) 
-    iPresentStatus.ACPRESENT = 1;
-  else
-    iPresentStatus.ACPRESENT = 0;
-  if(iRemaining == iFullChargeCapacity) 
-    iPresentStatus.FULLCHARGE = 1;
-  else 
-    iPresentStatus.FULLCHARGE = 0;
+  // Charging
+  iPresentStatus.CHARGING = bCharging;
+  iPresentStatus.ACPRESENT = bACPresent;
+  iPresentStatus.FULLCHARGE = (iRemaining == iFullChargeCapacity);
     
   // Discharging
   if(bDischarging) {
     iPresentStatus.DISCHARGING = 1;
     // if(iRemaining < iRemnCapacityLimit) iPresentStatus.BELOWRCL = 1;
     
-    if(iRunTimeToEmpty < iRemainTimeLimit) 
-      iPresentStatus.RTLEXPIRED = 1;
-    else
-      iPresentStatus.RTLEXPIRED = 0;
+    iPresentStatus.RTLEXPIRED = (iRunTimeToEmpty < iRemainTimeLimit);
 
   }
   else {

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -17,7 +17,7 @@ const char STRING_SERIAL[] PROGMEM = "UPS10";
 const byte bDeviceChemistry = IDEVICECHEMISTRY;
 const byte bOEMVendor = IOEMVENDOR;
 
-uint16_t iPresentStatus = 0, iPreviousStatus = 0;
+PresentStatus iPresentStatus = {}, iPreviousStatus = {};
 
 byte bRechargable = 1;
 byte bCapacityMode = 2;  // units are in %%
@@ -108,54 +108,54 @@ void loop() {
   
     // Charging
   if(bCharging) 
-    bitSet(iPresentStatus,PRESENTSTATUS_CHARGING);
+    iPresentStatus.CHARGING = 1;
   else
-    bitClear(iPresentStatus,PRESENTSTATUS_CHARGING);
+    iPresentStatus.CHARGING = 0;
   if(bACPresent) 
-    bitSet(iPresentStatus,PRESENTSTATUS_ACPRESENT);
+    iPresentStatus.ACPRESENT = 1;
   else
-    bitClear(iPresentStatus,PRESENTSTATUS_ACPRESENT);
+    iPresentStatus.ACPRESENT = 0;
   if(iRemaining == iFullChargeCapacity) 
-    bitSet(iPresentStatus,PRESENTSTATUS_FULLCHARGE);
+    iPresentStatus.FULLCHARGE = 1;
   else 
-    bitClear(iPresentStatus,PRESENTSTATUS_FULLCHARGE);
+    iPresentStatus.FULLCHARGE = 0;
     
   // Discharging
   if(bDischarging) {
-    bitSet(iPresentStatus,PRESENTSTATUS_DISCHARGING);
-    // if(iRemaining < iRemnCapacityLimit) bitSet(iPresentStatus,PRESENTSTATUS_BELOWRCL);
+    iPresentStatus.DISCHARGING = 1;
+    // if(iRemaining < iRemnCapacityLimit) iPresentStatus.BELOWRCL = 1;
     
     if(iRunTimeToEmpty < iRemainTimeLimit) 
-      bitSet(iPresentStatus, PRESENTSTATUS_RTLEXPIRED);
+      iPresentStatus.RTLEXPIRED = 1;
     else
-      bitClear(iPresentStatus, PRESENTSTATUS_RTLEXPIRED);
+      iPresentStatus.RTLEXPIRED = 0;
 
   }
   else {
-    bitClear(iPresentStatus,PRESENTSTATUS_DISCHARGING);
-    bitClear(iPresentStatus, PRESENTSTATUS_RTLEXPIRED);
+    iPresentStatus.DISCHARGING = 0;
+    iPresentStatus.RTLEXPIRED = 0;
   }
 
   // Shutdown requested
   if(iDelayBe4ShutDown > 0 ) {
-      bitSet(iPresentStatus, PRESENTSTATUS_SHUTDOWNREQ);
+      iPresentStatus.SHUTDOWNREQ = 1;
       Serial.println("shutdown requested");
   }
   else
-    bitClear(iPresentStatus, PRESENTSTATUS_SHUTDOWNREQ);
+    iPresentStatus.SHUTDOWNREQ = 0;
 
   // Shutdown imminent
-  if((iPresentStatus & (1 << PRESENTSTATUS_SHUTDOWNREQ)) || 
-     (iPresentStatus & (1 << PRESENTSTATUS_RTLEXPIRED))) {
-    bitSet(iPresentStatus, PRESENTSTATUS_SHUTDOWNIMNT);
+  if((iPresentStatus.SHUTDOWNREQ) || 
+     (iPresentStatus.RTLEXPIRED)) {
+    iPresentStatus.SHUTDOWNIMNT = 1;
     Serial.println("shutdown imminent");
   }
   else
-    bitClear(iPresentStatus, PRESENTSTATUS_SHUTDOWNIMNT);
+    iPresentStatus.SHUTDOWNIMNT = 0;
 
 
   
-  bitSet(iPresentStatus ,PRESENTSTATUS_BATTPRESENT);
+  iPresentStatus.BATTPRESENT = 1;
 
   
 

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -72,21 +72,31 @@
 #define HID_PD_IOEMINFORMATION       0x20 // Feature
 
 
-// PresenStatus dynamic flags
-#define PRESENTSTATUS_CHARGING       0x00
-#define PRESENTSTATUS_DISCHARGING    0x01
-#define PRESENTSTATUS_ACPRESENT      0x02
-#define PRESENTSTATUS_BATTPRESENT    0x03
-#define PRESENTSTATUS_BELOWRCL       0x04
-#define PRESENTSTATUS_RTLEXPIRED     0x05
-#define PRESENTSTATUS_NEEDREPLACE    0x06
-#define PRESENTSTATUS_VOLTAGENR      0x07
-#define PRESENTSTATUS_FULLCHARGE     0x08
-#define PRESENTSTATUS_FULLDISCHARGE  0x09
-#define PRESENTSTATUS_SHUTDOWNREQ    0x0A
-#define PRESENTSTATUS_SHUTDOWNIMNT   0x0B
-#define PRESENTSTATUS_COMMLOST       0x0C
-#define PRESENTSTATUS_OVERLOAD       0x0D
+// PresentStatus dynamic flags
+struct PresentStatus {
+  uint8_t CHARGING : 1;     // bit 0x00
+  uint8_t DISCHARGING : 1;  // bit 0x01
+  uint8_t ACPRESENT : 1;    // bit 0x02
+  uint8_t BATTPRESENT : 1;  // bit 0x03
+  uint8_t BELOWRCL : 1;     // bit 0x04
+  uint8_t RTLEXPIRED : 1;   // bit 0x05
+  uint8_t NEEDREPLACE : 1;  // bit 0x06
+  uint8_t VOLTAGENR : 1;    // bit 0x07
+  
+  uint8_t FULLCHARGE : 1;   // bit 0x08
+  uint8_t FULLDISCHARGE : 1;// bit 0x09
+  uint8_t SHUTDOWNREQ : 1;  // bit 0x0A
+  uint8_t SHUTDOWNIMNT : 1; // bit 0x0B
+  uint8_t COMMLOST : 1;     // bit 0x0C
+  uint8_t OVERLOAD : 1;     // bit 0x0D
+  uint8_t unused1 : 1;
+  uint8_t unused2 : 1;
+  
+  operator uint16_t () {
+      return *(uint16_t*)(this); // switch to std::bit_cast after migrating to C++20
+  }
+};
+static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 
 
 


### PR DESCRIPTION
Utilize [bit-field](https://en.cppreference.com/w/cpp/language/bit_field) to simplify by eliminating the need for `bitSet` and `bitClear` calls to set/clear bit fields.

Leveraging the fact that the Arduino C/C++ compiler defines "true" as 1 according to https://www.arduino.cc/reference/en/language/variables/constants/truefalse/ . This makes it safe to assign a `bool` value to a bit-field.

I've kept the `PresentStatus` bit-fields in uppercase to reduce the amount of changes. Can of course change them to lowercase if desired.