### PR TITLE
Extend sample to also set ManufacturerDate

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -31,7 +31,7 @@ uint16_t iAvgTimeToEmpty = 7200;
 uint16_t iRemainTimeLimit = 600;
 int16_t  iDelayBe4Reboot = -1;
 int16_t  iDelayBe4ShutDown = -1;
-
+uint16_t iManufacturerDate = 0; // initialized in setup function
 byte iAudibleAlarmCtrl = 2; // 1 - Disabled, 2 - Enabled, 3 - Muted
 
 
@@ -92,6 +92,9 @@ void setup() {
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
+  uint16_t year = 2024, month = 10, day = 12;
+  iManufacturerDate = (year - 1980)*512 + month*32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
+  PowerDevice.setFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 void loop() {


### PR DESCRIPTION
Make the sample more complete by also setting `ManufacturerDate` to October 12. 2024 (today).

I've already verified that it's possible to retrieve the same date back with the following code on Windows:
```
BATTERY_QUERY_INFORMATION bqi = {};
bqi.InformationLevel = BatteryManufactureDate;
bqi.BatteryTag = GetBatteryTag(device);

BATTERY_MANUFACTURE_DATE date = {};
DWORD bytes_returned = 0;
BOOL ok = DeviceIoControl(device, IOCTL_BATTERY_QUERY_INFORMATION, &bqi, sizeof(bqi), &date, sizeof(date), &bytes_returned, nullptr);
printf("ManufactureDate: %u-%u-%u\n", date.Year, date.Month, date.Day);
```