### PR TITLE
Update PresentStatus fields to match usage names

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -110,43 +110,43 @@ void loop() {
   iRunTimeToEmpty = (uint16_t)round((float)iAvgTimeToEmpty*iRemaining/100);
   
   // Charging
-  iPresentStatus.CHARGING = bCharging;
-  iPresentStatus.ACPRESENT = bACPresent;
-  iPresentStatus.FULLCHARGE = (iRemaining == iFullChargeCapacity);
+  iPresentStatus.Charging = bCharging;
+  iPresentStatus.ACPresent = bACPresent;
+  iPresentStatus.FullyCharged = (iRemaining == iFullChargeCapacity);
     
   // Discharging
   if(bDischarging) {
-    iPresentStatus.DISCHARGING = 1;
-    // if(iRemaining < iRemnCapacityLimit) iPresentStatus.BELOWRCL = 1;
+    iPresentStatus.Discharging = 1;
+    // if(iRemaining < iRemnCapacityLimit) iPresentStatus.BelowRemainingCapacityLimit = 1;
     
-    iPresentStatus.RTLEXPIRED = (iRunTimeToEmpty < iRemainTimeLimit);
+    iPresentStatus.RemainingTimeLimitExpired = (iRunTimeToEmpty < iRemainTimeLimit);
 
   }
   else {
-    iPresentStatus.DISCHARGING = 0;
-    iPresentStatus.RTLEXPIRED = 0;
+    iPresentStatus.Discharging = 0;
+    iPresentStatus.RemainingTimeLimitExpired = 0;
   }
 
   // Shutdown requested
   if(iDelayBe4ShutDown > 0 ) {
-      iPresentStatus.SHUTDOWNREQ = 1;
+      iPresentStatus.ShutdownRequested = 1;
       Serial.println("shutdown requested");
   }
   else
-    iPresentStatus.SHUTDOWNREQ = 0;
+    iPresentStatus.ShutdownRequested = 0;
 
   // Shutdown imminent
-  if((iPresentStatus.SHUTDOWNREQ) || 
-     (iPresentStatus.RTLEXPIRED)) {
-    iPresentStatus.SHUTDOWNIMNT = 1;
+  if((iPresentStatus.ShutdownRequested) || 
+     (iPresentStatus.RemainingTimeLimitExpired)) {
+    iPresentStatus.ShutdownImminent = 1;
     Serial.println("shutdown imminent");
   }
   else
-    iPresentStatus.SHUTDOWNIMNT = 0;
+    iPresentStatus.ShutdownImminent = 0;
 
 
   
-  iPresentStatus.BATTPRESENT = 1;
+  iPresentStatus.BatteryPresent = 1;
 
   
 

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -74,21 +74,21 @@
 
 // PresentStatus dynamic flags
 struct PresentStatus {
-  uint8_t CHARGING : 1;     // bit 0x00
-  uint8_t DISCHARGING : 1;  // bit 0x01
-  uint8_t ACPRESENT : 1;    // bit 0x02
-  uint8_t BATTPRESENT : 1;  // bit 0x03
-  uint8_t BELOWRCL : 1;     // bit 0x04
-  uint8_t RTLEXPIRED : 1;   // bit 0x05
-  uint8_t NEEDREPLACE : 1;  // bit 0x06
-  uint8_t VOLTAGENR : 1;    // bit 0x07
+  uint8_t Charging : 1;                   // bit 0x00
+  uint8_t Discharging : 1;                // bit 0x01
+  uint8_t ACPresent : 1;                  // bit 0x02
+  uint8_t BatteryPresent : 1;             // bit 0x03
+  uint8_t BelowRemainingCapacityLimit : 1;// bit 0x04
+  uint8_t RemainingTimeLimitExpired : 1;  // bit 0x05
+  uint8_t NeedReplacement : 1;            // bit 0x06
+  uint8_t VoltageNotRegulated : 1;        // bit 0x07
   
-  uint8_t FULLCHARGE : 1;   // bit 0x08
-  uint8_t FULLDISCHARGE : 1;// bit 0x09
-  uint8_t SHUTDOWNREQ : 1;  // bit 0x0A
-  uint8_t SHUTDOWNIMNT : 1; // bit 0x0B
-  uint8_t COMMLOST : 1;     // bit 0x0C
-  uint8_t OVERLOAD : 1;     // bit 0x0D
+  uint8_t FullyCharged : 1;               // bit 0x08
+  uint8_t FullyDischarged : 1;            // bit 0x09
+  uint8_t ShutdownRequested : 1;          // bit 0x0A
+  uint8_t ShutdownImminent : 1;           // bit 0x0B
+  uint8_t CommunicationLost : 1;          // bit 0x0C
+  uint8_t Overload : 1;                   // bit 0x0D
   uint8_t unused1 : 1;
   uint8_t unused2 : 1;
   


### PR DESCRIPTION
Follow-up to #24.

Change casing and spell out the `PresentStatus` fields, so that they matches the corresponding HID usage names in HIDPowerDevice.cpp. Done to make the code a bit easier to follow.