### PR TITLE
Remove unused "Overload" parameter from HID descriptor

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -209,11 +209,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
     0x81, 0xA3, //       INPUT (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Bitfield)
     0x09, 0x73, //       USAGE (CommunicationLost)
     0xB1, 0xA3, //       FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Volatile, Bitfield)
-    0x09, 0x65, //       USAGE (Overload)
-    0x81, 0xA3, //       INPUT (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Bitfield)
-    0x09, 0x65, //       USAGE (Overload)
-    0xB1, 0xA3, //       FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Volatile, Bitfield)
-    0x95, 0x02, //       REPORT_COUNT (2)
+    0x95, 0x03, //       REPORT_COUNT (3)
     0x81, 0x01, //       INPUT (Constant, Array, Absolute)
     0xB1, 0x01, //       FEATURE (Constant, Array, Absolute, No Wrap, Linear, Preferred State, No Null Position, Nonvolatile, Bitfield)      
     0xC0,       //     END_COLLECTION    

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -88,9 +88,9 @@ struct PresentStatus {
   uint8_t SHUTDOWNREQ : 1;  // bit 0x0A
   uint8_t SHUTDOWNIMNT : 1; // bit 0x0B
   uint8_t COMMLOST : 1;     // bit 0x0C
-  uint8_t OVERLOAD : 1;     // bit 0x0D
   uint8_t unused1 : 1;
   uint8_t unused2 : 1;
+  uint8_t unused3 : 1;
   
   operator uint16_t () {
       return *(uint16_t*)(this); // switch to std::bit_cast after migrating to C++20


### PR DESCRIPTION
Proposal to simplify the quite complex HID descriptor a bit by removing the `Overload` parameter. I'm furthermore unsure if operating systems actually utilize this parameter.

Had to adjust the REPORT_COUNT from 2 to 3 at the end to adjust padding, so that the report size remain byte aligned.