### PR TITLE
Fix broken HIDPowerDevice_::sendDate method

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -31,7 +31,6 @@ uint16_t iAvgTimeToEmpty = 7200;
 uint16_t iRemainTimeLimit = 600;
 int16_t  iDelayBe4Reboot = -1;
 int16_t  iDelayBe4ShutDown = -1;
-uint16_t iManufacturerDate = 0; // initialized in setup function
 byte iAudibleAlarmCtrl = 2; // 1 - Disabled, 2 - Enabled, 3 - Muted
 
 
@@ -92,9 +91,7 @@ void setup() {
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
-  uint16_t year = 2024, month = 10, day = 12;
-  iManufacturerDate = (year - 1980)*512 + month*32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-  PowerDevice.setFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
+  PowerDevice.sendDate(HID_PD_MANUFACTUREDATE, 2024, 10, 12);
 }
 
 void loop() {

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -91,7 +91,7 @@ void setup() {
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
   PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
-  PowerDevice.sendDate(HID_PD_MANUFACTUREDATE, 2024, 10, 12);
+  PowerDevice.sendManufacturerDate(2024, 10, 12);
 }
 
 void loop() {

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -250,8 +250,8 @@ void HIDPowerDevice_::end(void) {
 }
 
 int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
-    uint16_t bval = (year - 1980)*512 + month * 32 + day;
-    return HID().SendReport(id, &bval, sizeof (bval));
+    iManufacturerDate = (year - 1980)*512 + month * 32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
+    return HID().SendReport(id, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -249,9 +249,9 @@ void HIDPowerDevice_::setSerial(const char* s) {
 void HIDPowerDevice_::end(void) {
 }
 
-int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
+int HIDPowerDevice_::sendManufacturerDate(uint16_t year, uint8_t month, uint8_t day) {
     iManufacturerDate = (year - 1980)*512 + month * 32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-    return HID().SetFeature(id, &iManufacturerDate, sizeof(iManufacturerDate));
+    return HID().SetFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -251,7 +251,7 @@ void HIDPowerDevice_::end(void) {
 
 int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
     iManufacturerDate = (year - 1980)*512 + month * 32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-    return HID().SendReport(id, &iManufacturerDate, sizeof(iManufacturerDate));
+    return HID().SetFeature(id, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -121,7 +121,7 @@ public:
   
   void end(void);
   
-  int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
+  int sendManufacturerDate(uint16_t year, uint8_t month, uint8_t day);
   int sendReport(uint16_t id, const void* bval, int len);
   
   int setFeature(uint16_t id, const void* data, int len);

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -128,6 +128,8 @@ public:
   
   int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
 
+private:
+  uint16_t iManufacturerDate = 0;
 };
 
 extern HIDPowerDevice_ PowerDevice;


### PR DESCRIPTION
See #29 for an alternative proposal.

The method currently uses a local `bval` variable as argument when calling `HID().SendReport(...)`. This is problematic, since the `SendReport` method doesn't use `bval` immediately. It instead captures a pointer to `bval` which is accessed when the report is sent at a later point. This leads to a **use-after-free situation** when the pointer captured by `SendReport` no longer point to `bval`, but some other unknown data.

Propose to fix the issue by introducing a new `iManufacturerDate` member in the `HIDPowerDevice` class to act as persistent storage for the date value.

Also, change `HIDPowerDevice_::sendDate` to send the date as a `FEATURE` report _instead_ of a `INPUT` report, so that it matches the `ManufacturerDate` parameter in the HID descriptor. This is also required in order for the date to be picked up on Windows.