### PR TITLE
Remove unused and broken HIDPowerDevice_::sendDate method

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -249,11 +249,6 @@ void HIDPowerDevice_::setSerial(const char* s) {
 void HIDPowerDevice_::end(void) {
 }
 
-int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
-    uint16_t bval = (year - 1980)*512 + month * 32 + day;
-    return HID().SendReport(id, &bval, sizeof (bval));
-}
-
 int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {
     return HID().SendReport(id, bval, len);
 }

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -121,7 +121,6 @@ public:
   
   void end(void);
   
-  int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
   int sendReport(uint16_t id, const void* bval, int len);
   
   int setFeature(uint16_t id, const void* data, int len);


### PR DESCRIPTION
Alternative to #28.

The method currently uses a local `bval` variable as argument when calling `HID().SendReport(...)`. This is problematic, since the `SendReport` method doesn't use `bval` immediately. It instead captures a pointer to `bval` which is accessed when the report is sent at a later point. This leads to a **use-after-free situation** when the pointer captured by `SendReport` no longer point to `bval`, but some other unknown data.

Proposing to delete the `sendDate` method, since it's both broken and unused. Client code can anyhow set date parameters through manual `setFeature` calls as was done in #25.