### PR TITLE
Change bCountryCode from 0x21 (US) to 0x00 (irrelevant)

### DIFF
--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -162,7 +162,7 @@ private:
 // https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
 HID_& HID();
 
-#define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0x21, 1, 0x22, lowByte(length), highByte(length) }
+#define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0, 1, 0x22, lowByte(length), highByte(length) }
 
 #endif // USBCON
 


### PR DESCRIPTION
Update the `D_HIDREPORT` macro to set `bCountryCode` from 0x21 (US) to 0x00 (irrelevant) in the HID interface descriptor. Done since there's no reason for making battery and UPS devices specific to a single country.

This also makes the sources more similar to to upstream Arduino sources on https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/HID/src/HID.h

Documentation: https://wiki.osdev.org/USB_Human_Interface_Devices#USB_Report_Protocol