### PR TITLE
Demonstrate how to expose multiple batteries - DO NOT MERGE

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -65,36 +65,36 @@ void setup() {
   pinMode(COMMLOSTPIN, OUTPUT); // output is on once communication is lost with the host, otherwise off.
 
 
-  PowerDevice.setFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+  PowerDevice.SetFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
   
-  PowerDevice.setFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-  PowerDevice.setFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
-  PowerDevice.setFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
-  PowerDevice.setFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
-  PowerDevice.setFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
-  PowerDevice.setFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
+  PowerDevice.SetFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+  PowerDevice.SetFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
+  PowerDevice.SetFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
+  PowerDevice.SetFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
+  PowerDevice.SetFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
+  PowerDevice.SetFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
   
-  PowerDevice.setFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
-  PowerDevice.setFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
-  PowerDevice.setFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
-  PowerDevice.setFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
+  PowerDevice.SetFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
+  PowerDevice.SetFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
+  PowerDevice.SetFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
+  PowerDevice.SetFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
 
   PowerDevice.setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
   PowerDevice.setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
 
-  PowerDevice.setFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
+  PowerDevice.SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
 
-  PowerDevice.setFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
-  PowerDevice.setFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
-  PowerDevice.setFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-  PowerDevice.setFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
-  PowerDevice.setFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
-  PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
-  PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
+  PowerDevice.SetFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
+  PowerDevice.SetFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
+  PowerDevice.SetFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+  PowerDevice.SetFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
+  PowerDevice.SetFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
+  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
+  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
   uint16_t year = 2024, month = 10, day = 12;
   iManufacturerDate = (year - 1980)*512 + month*32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-  PowerDevice.setFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
+  PowerDevice.SetFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 void loop() {
@@ -166,9 +166,9 @@ void loop() {
 
   if((iPresentStatus != iPreviousStatus) || (iRemaining != iPrevRemaining) || (iRunTimeToEmpty != iPrevRunTimeToEmpty) || (iIntTimer>MINUPDATEINTERVAL) ) {
 
-    PowerDevice.sendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-    if(bDischarging) PowerDevice.sendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-    iRes = PowerDevice.sendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+    PowerDevice.SendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+    if(bDischarging) PowerDevice.SendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+    iRes = PowerDevice.SendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
 
     if(iRes <0 ) {
       digitalWrite(COMMLOSTPIN, HIGH);

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -51,50 +51,53 @@ int iRes=0;
 void setup() {
 
   Serial.begin(57600);
-    
-  PowerDevice.begin();
+   
+  for (int i = 0; i < BATTERY_COUNT; i++) {
+    PowerDevice[i].begin();
   
-  // Serial No is set in a special way as it forms Arduino port name
-  PowerDevice.setSerial(STRING_SERIAL); 
+    // Serial No is set in a special way as it forms Arduino port name
+    PowerDevice[i].setSerial(STRING_SERIAL); 
   
-  // Used for debugging purposes. 
-  PowerDevice.setOutput(Serial);
+    // Used for debugging purposes. 
+    PowerDevice[i].setOutput(Serial);
+  }
   
   pinMode(CHGDCHPIN, INPUT_PULLUP); // ground this pin to simulate power failure. 
   pinMode(RUNSTATUSPIN, OUTPUT);  // output flushing 1 sec indicating that the arduino cycle is running. 
   pinMode(COMMLOSTPIN, OUTPUT); // output is on once communication is lost with the host, otherwise off.
 
-
-  PowerDevice.SetFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+ for (int i = 0; i < BATTERY_COUNT; i++) {
+  PowerDevice[i].SetFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
   
-  PowerDevice.SetFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-  PowerDevice.SetFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
-  PowerDevice.SetFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
-  PowerDevice.SetFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
-  PowerDevice.SetFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
-  PowerDevice.SetFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
+  PowerDevice[i].SetFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+  PowerDevice[i].SetFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
+  PowerDevice[i].SetFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
+  PowerDevice[i].SetFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
+  PowerDevice[i].SetFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
+  PowerDevice[i].SetFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
   
-  PowerDevice.SetFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
-  PowerDevice.SetFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
-  PowerDevice.SetFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
-  PowerDevice.SetFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
+  PowerDevice[i].SetFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
+  PowerDevice[i].SetFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
+  PowerDevice[i].SetFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
+  PowerDevice[i].SetFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
 
-  PowerDevice.setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
-  PowerDevice.setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
+  PowerDevice[i].setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
+  PowerDevice[i].setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
 
-  PowerDevice.SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
+  PowerDevice[i].SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
 
-  PowerDevice.SetFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
-  PowerDevice.SetFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
-  PowerDevice.SetFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-  PowerDevice.SetFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
-  PowerDevice.SetFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
-  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
-  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
+  PowerDevice[i].SetFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
+  PowerDevice[i].SetFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
+  PowerDevice[i].SetFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+  PowerDevice[i].SetFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
+  PowerDevice[i].SetFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
+  PowerDevice[i].SetFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
+  PowerDevice[i].SetFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
   uint16_t year = 2024, month = 10, day = 12;
   iManufacturerDate = (year - 1980)*512 + month*32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-  PowerDevice.SetFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
+  PowerDevice[i].SetFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
+ }
 }
 
 void loop() {
@@ -166,9 +169,11 @@ void loop() {
 
   if((iPresentStatus != iPreviousStatus) || (iRemaining != iPrevRemaining) || (iRunTimeToEmpty != iPrevRunTimeToEmpty) || (iIntTimer>MINUPDATEINTERVAL) ) {
 
-    PowerDevice.SendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-    if(bDischarging) PowerDevice.SendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-    iRes = PowerDevice.SendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+    for (int i = 0; i < BATTERY_COUNT; i++) {
+      PowerDevice[i].SendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+      if(bDischarging) PowerDevice[i].SendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+      iRes = PowerDevice[i].SendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+    }
 
     if(iRes <0 ) {
       digitalWrite(COMMLOSTPIN, HIGH);

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -49,17 +49,12 @@ int iRes=0;
 
 
 void setup() {
-
-  Serial.begin(57600);
    
   for (int i = 0; i < BATTERY_COUNT; i++) {
     PowerDevice[i].begin();
   
     // Serial No is set in a special way as it forms Arduino port name
     PowerDevice[i].setSerial(STRING_SERIAL); 
-  
-    // Used for debugging purposes. 
-    PowerDevice[i].setOutput(Serial);
   }
   
   pinMode(CHGDCHPIN, INPUT_PULLUP); // ground this pin to simulate power failure. 
@@ -133,7 +128,6 @@ void loop() {
   // Shutdown requested
   if(iDelayBe4ShutDown > 0 ) {
       iPresentStatus.ShutdownRequested = 1;
-      Serial.println("shutdown requested");
   }
   else
     iPresentStatus.ShutdownRequested = 0;
@@ -142,7 +136,6 @@ void loop() {
   if((iPresentStatus.ShutdownRequested) || 
      (iPresentStatus.RemainingTimeLimitExpired)) {
     iPresentStatus.ShutdownImminent = 1;
-    Serial.println("shutdown imminent");
   }
   else
     iPresentStatus.ShutdownImminent = 0;
@@ -186,10 +179,5 @@ void loop() {
     iPrevRemaining = iRemaining[0];
     iPrevRunTimeToEmpty = iRunTimeToEmpty;
   }
-  
-
-  Serial.println(iRemaining);
-  Serial.println(iRunTimeToEmpty);
-  Serial.println(iRes);
   
 }

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -33,7 +33,7 @@ int HID_::getInterface(uint8_t* interfaceCount)
     HIDDescriptor hidInterface = {
         D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
         D_HIDREPORT(descriptorSize),
-        D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14)
+        D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14)
     };
     return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
@@ -167,9 +167,9 @@ bool HID_::LockFeature(uint16_t id, bool lock) {
 
 int HID_::SendReport(uint16_t id, const void* data, int len)
 {
-    auto ret = USB_Send(HID_TX, &id, 1);
+    auto ret = USB_Send(pluggedEndpoint, &id, 1);
     if (ret < 0) return ret;
-    auto ret2 = USB_Send(HID_TX | TRANSFER_RELEASE, data, len);
+    auto ret2 = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
     if (ret2 < 0) return ret2;
     return ret + ret2;
 }

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -31,10 +31,9 @@ int HID_::getInterface(uint8_t* interfaceCount)
 {
     *interfaceCount += 1; // uses 1
     HIDDescriptor hidInterface = {
-        D_INTERFACE(pluggedInterface, 2, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
+        D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
         D_HIDREPORT(descriptorSize),
-        D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14),
-        D_ENDPOINT(USB_ENDPOINT_OUT(HID_RX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x0A)
+        D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14)
     };
     return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
@@ -254,12 +253,11 @@ bool HID_::setup(USBSetup& setup)
     return false;
 }
 
-HID_::HID_(void) : PluggableUSBModule(2, 1, epType),
+HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
                    rootNode(NULL), descriptorSize(0),
                    protocol(HID_REPORT_PROTOCOL), idle(1)
 {
     epType[0] = EP_TYPE_INTERRUPT_IN;
-        epType[1] = EP_TYPE_INTERRUPT_OUT;
     PluggableUSB().plug(this);
 }
 

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -21,12 +21,6 @@
 
 #if defined(USBCON)
 
-HID_& HID()
-{
-    static HID_ obj;
-    return obj;
-}
-
 int HID_::getInterface(uint8_t* interfaceCount)
 {
     *interfaceCount += 1; // uses 1

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -61,14 +61,6 @@
 #define HID_REPORT_TYPE_OUTPUT  2
 #define HID_REPORT_TYPE_FEATURE 3
 
-#define HID_INTERFACE		(CDC_ACM_INTERFACE + CDC_INTERFACE_COUNT)		// HID Interface
-#define HID_FIRST_ENDPOINT	(CDC_FIRST_ENDPOINT + CDC_ENPOINT_COUNT)
-#define HID_ENDPOINT_INT	(HID_FIRST_ENDPOINT)
-#define HID_ENDPOINT_OUT	(HID_FIRST_ENDPOINT+1)   
-
-#define HID_TX HID_ENDPOINT_INT
-#define HID_RX HID_ENDPOINT_OUT     //++ EP  HID_RX for ease of use with USB_Available & USB_Rec
-
 typedef struct
 {
   uint8_t len;      // 9

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -157,11 +157,6 @@ private:
     
 };
 
-// Replacement for global singleton.
-// This function prevents static-initialization-order-fiasco
-// https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
-HID_& HID();
-
 #define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0x21, 1, 0x22, lowByte(length), highByte(length) }
 
 #endif // USBCON

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -87,7 +87,6 @@ typedef struct
   InterfaceDescriptor hid;
   HIDDescDescriptor   desc;
   EndpointDescriptor  in;
-  EndpointDescriptor  out;                  //added
 } HIDDescriptor;
 
 class HIDReport {
@@ -139,7 +138,7 @@ protected:
     uint8_t getShortName(char* name) override;
     
 private:
-    uint8_t epType[2];
+    uint8_t epType[1];
 
     HIDSubDescriptor* rootNode;
     uint16_t descriptorSize;

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -257,7 +257,7 @@ int HIDPowerDevice_::setStringFeature(uint8_t id, const uint8_t* index, const ch
     return res;
 }
 
-HIDPowerDevice_ PowerDevice;
+HIDPowerDevice_ PowerDevice[BATTERY_COUNT];
 
 #endif
 

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -224,26 +224,18 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 HIDPowerDevice_::HIDPowerDevice_(void) {
     static HIDSubDescriptor node(_hidReportDescriptor, sizeof (_hidReportDescriptor));
 
-    HID().AppendDescriptor(&node);
+    AppendDescriptor(&node);
 }
 
 void HIDPowerDevice_::begin(void) {
-    HID().begin();
+    HID_::begin();
     
     // set string ID here
     
-    HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
-    HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
-    HID().SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
+    SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
+    SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
+    SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
     
-}
-
-void HIDPowerDevice_::setOutput(Serial_& out) {
-    HID().setOutput(out);
-}
-
-void HIDPowerDevice_::setSerial(const char* s) {
-    HID().setSerial(s);
 }
 
 void HIDPowerDevice_::end(void) {
@@ -251,24 +243,16 @@ void HIDPowerDevice_::end(void) {
 
 int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
     uint16_t bval = (year - 1980)*512 + month * 32 + day;
-    return HID().SendReport(id, &bval, sizeof (bval));
-}
-
-int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {
-    return HID().SendReport(id, bval, len);
-}
-
-int HIDPowerDevice_::setFeature(uint16_t id, const void *data, int len) {
-    return HID().SetFeature(id, data, len);
+    return SendReport(id, &bval, sizeof (bval));
 }
 
 int HIDPowerDevice_::setStringFeature(uint8_t id, const uint8_t* index, const char* data) {
     
-    int res = HID().SetFeature(id, index, 1);
+    int res = SetFeature(id, index, 1);
     
     if(res == 0) return 0;
     
-    res += HID().SetFeature(0xFF00 | *index , data, strlen_P(data));
+    res += SetFeature(0xFF00 | *index , data, strlen_P(data));
     
     return res;
 }

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -121,8 +121,10 @@ public:
   int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
 };
 
-extern HIDPowerDevice_ PowerDevice;
+// as many batteries as supported by the HW
+#define BATTERY_COUNT (USB_ENDPOINTS - CDC_FIRST_ENDPOINT - CDC_ENPOINT_COUNT) // 3 by default; 6 if defining CDC_DISABLED
 
+extern HIDPowerDevice_ PowerDevice[BATTERY_COUNT];
 
 #endif
 #endif

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -102,7 +102,7 @@ static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 
 
 
-class HIDPowerDevice_  {
+class HIDPowerDevice_ : public HID_ {
     
 private:
     
@@ -114,20 +114,11 @@ public:
   HIDPowerDevice_(void);
   void begin(void);
   
-  void setOutput(Serial_&);
-  
-  void setSerial(const char*);
-  
-  
   void end(void);
   
   int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
-  int sendReport(uint16_t id, const void* bval, int len);
-  
-  int setFeature(uint16_t id, const void* data, int len);
   
   int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
-
 };
 
 extern HIDPowerDevice_ PowerDevice;


### PR DESCRIPTION
The PR is **NOT intended for merging**, only to showcase how multiple batteries can be simulated after  #36 and #37 are merged.

There seems to be an Arduino HW limit of [7 USB endpoints](https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/USBDesc.h#L22). This limits the maximum number of simulated batteries to 3 by default, but this can be increased to 6 by defining `CDC_DISABLED` in  `C:\Users\<username>\AppData\Local\Arduino15\packages\arduino\hardware\avr\<version>\cores\arduino\USBDesc.h` to disable the USB serial console endpoints. If doing so, then one needs to use the Arduino's reset button to be able to flash it.

## Windows 10 screenshots
Screenshots where  `CDC_DISABLED` is defined to enable 6 batteries. `UPS.ino` has also been modified to expose slightly different charge levels for each battery to make the example more interesting:  
![image](https://github.com/user-attachments/assets/a4a27081-7d68-4e63-a219-713f017c81a8)
![image](https://github.com/user-attachments/assets/e0410a98-7341-48c8-b46e-15837f020502)

## Windows 2000 screenshot
HID battery support actually goes back to Windows 2000, which was released 25 years ago.
![image](https://github.com/user-attachments/assets/15480844-ee9f-4bed-bce5-51915188498b)

The screenshot was obtained by creating a Windows 2000 SP4 VM in VirtualBox and forwarding the Arduino USB device to the VirtualBox VM. A default Windows 2000 installation will then automatically detect the HID battery devices, even _without_ Windows Update connectivity.