### PR TITLE
Change SendReport & sendDate "id" values from 16 to 8bits

### DIFF
--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -166,7 +166,7 @@ bool HID_::LockFeature(uint16_t id, bool lock) {
 }
 
 
-int HID_::SendReport(uint16_t id, const void* data, int len)
+int HID_::SendReport(uint8_t id, const void* data, int len)
 {
     auto ret = USB_Send(HID_TX, &id, 1);
     if (ret < 0) return ret;

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -115,7 +115,7 @@ class HID_ : public PluggableUSBModule
 public:
     HID_(void);
     int begin(void);
-    int SendReport(uint16_t id, const void* data, int len);
+    int SendReport(uint8_t id, const void* data, int len);
     int SetFeature(uint16_t id, const void* data, int len);
     bool LockFeature(uint16_t id, bool lock);
     

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -249,12 +249,12 @@ void HIDPowerDevice_::setSerial(const char* s) {
 void HIDPowerDevice_::end(void) {
 }
 
-int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
+int HIDPowerDevice_::sendDate(uint8_t id, uint16_t year, uint8_t month, uint8_t day) {
     uint16_t bval = (year - 1980)*512 + month * 32 + day;
     return HID().SendReport(id, &bval, sizeof (bval));
 }
 
-int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {
+int HIDPowerDevice_::sendReport(uint8_t id, const void* bval, int len) {
     return HID().SendReport(id, bval, len);
 }
 

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -121,8 +121,8 @@ public:
   
   void end(void);
   
-  int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
-  int sendReport(uint16_t id, const void* bval, int len);
+  int sendDate(uint8_t id, uint16_t year, uint8_t month, uint8_t day);
+  int sendReport(uint8_t id, const void* bval, int len);
   
   int setFeature(uint16_t id, const void* data, int len);
   


### PR DESCRIPTION
The underlying `HID_::sendReport` method is anyhow only transmitting the first byte of the "id" field, so the content of the second byte is currently ignored. One can then just as well change the "id" argument type from 16 to 8bits.

Update the `HIDPowerDevice_::sendDate` the same way, since it's just passing on the "id" argument to `HID_::sendReport`.

This also makes the HID class more similar to the upstream Arduino implementation on https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/HID/src/HID.h#L96 that is already using `uint8_t` for HID report IDs. This is consistent with the HID specification, that states that ReportID values are 8bits.